### PR TITLE
fix: use clone to avoid in-place operation error when training

### DIFF
--- a/ablang2/models/ablang2/encoderblock.py
+++ b/ablang2/models/ablang2/encoderblock.py
@@ -43,7 +43,7 @@ class TransformerEncoder(torch.nn.Module):
     def forward(self, hidden_embed, attn_mask=None, return_attn_weights: bool = False):
         
         residual = hidden_embed
-        hidden_embed = self.pre_attn_layer_norm(hidden_embed)
+        hidden_embed = self.pre_attn_layer_norm(hidden_embed.clone())
         hidden_embed, attn_weights = self.multihead_attention(
             hidden_embed, 
             attn_mask=attn_mask, 


### PR DESCRIPTION
Hello,

I tried training this locally. An error popped up complaining about in-place operations on a variable that requires gradients. I fixed it by adding `.clone()` as shown.

Best,
Jonathan